### PR TITLE
Create HTML landing pages for articles

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,7 @@
+title: The R Journal
+license: CC-BY
+subjects: statistics, visualization, R
+
 issues:
   - issue: accepted
     articles:

--- a/_includes/metadata.html
+++ b/_includes/metadata.html
@@ -1,15 +1,17 @@
 <meta name="citation_title" content="{{ page.title }}"/>
 {% for author in page.author %}  
 <meta name="citation_author" content="{{ author }}"/> {% endfor %}
-<meta name="citation_publication_date" content="{{ page.issue }}"/>
+<meta name="citation_publication_date" content="{{ page.year }}"/>
 <meta name="citation_journal_title" content="{{ site.title }}"/>
-<meta name="citation_issue" content="{{ page.issue }}"/>
+<meta name="citation_issue" content="{{ page.num }}"/>
+<meta name="citation_volume" content="{{ page.volume }}"/>
 <meta name="citation_firstpage" content="{{ page.pages[0] }}"/>
 <meta name="citation_lastpage" content="{{ page.pages[1] }}"/>
 <meta name="citation_pdf_url" content="{{ page.pdf }}"/>
 
 
 <meta property="dc:title" content="{{ page.title }}" />
+<meta property="dc:date" content="{{ page.year }}" />
 <meta property="dc:format" content="text/html" />
 <meta property="dc:language" content="en" />
 <meta property="dc:identifier" content="{{ page.url }}" />

--- a/_includes/metadata.html
+++ b/_includes/metadata.html
@@ -1,0 +1,19 @@
+<meta name="citation_title" content="{{ page.title }}"/>
+{% for author in page.author %}  
+<meta name="citation_author" content="{{ author }}"/> {% endfor %}
+<meta name="citation_publication_date" content="{{ page.issue }}"/>
+<meta name="citation_journal_title" content="{{ site.title }}"/>
+<meta name="citation_issue" content="{{ page.issue }}"/>
+<meta name="citation_firstpage" content="{{ page.pages[0] }}"/>
+<meta name="citation_lastpage" content="{{ page.pages[1] }}"/>
+<meta name="citation_pdf_url" content="{{ page.pdf }}"/>
+
+
+<meta property="dc:title" content="{{ page.title }}" />
+<meta property="dc:format" content="text/html" />
+<meta property="dc:language" content="en" />
+<meta property="dc:identifier" content="{{ page.url }}" />
+<meta property="dc:rights" content="{{ site.license }}" />
+<meta property="dc:source" content="{{ site.title }}" />
+<meta property="dc:subject" content="{{ site.subjects }}" /> 
+<meta property="dc:type" content="Article" /> 

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -1,0 +1,66 @@
+---
+navigation:
+- text: "Home"
+  url: "/index.html"
+- text: "Current Issue"
+  url: "/archive/2013-1" 
+- text: "Accepted Articles"
+  url: "/archive/accepted/" 
+- text: "Archive"
+  url: "/archive" 
+- text: "Submissions"
+  url: "/submissions.html" 
+- text: "Editorial Board"
+  url: "/board.html" 
+---
+<!DOCTYPE html>
+
+<html>
+<head>
+  <title>{%if page_title %}{{page_title}}{% else %}{{page.title}}{% endif %}. The R Journal</title>
+  <link rel="stylesheet" type="text/css" href="/r-journal.css">
+  <link rel="alternate" type="application/rss+xml" title="Rjournal RSS feed"
+    href="/rss.atom">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+
+ {% include metadata.html %}
+
+</head>
+
+<body>
+
+<div id="header">
+<h1>The <img src="/r-logo.png" width="101" height="77" alt="R" /> Journal</h1>
+
+<p id="rss"><a href="/rss.atom"><img src="/rss.png" alt="">RSS Feed</a><br />
+ISSN: 2073-4859</p>
+</div>
+
+<div id = "spacer"></div>
+
+<div id="navigation"><ul>
+{% for link in page.navigation %}
+  {% if page.url == link.url %}
+    {% assign current = 'current' %}
+  {% else %}
+    {% assign current = nil %}
+  {% endif %}
+  <li class="{{ current }}"><a href="{{ link.url }}">{{ link.text }}</a></li>
+{% endfor %}
+</ul></div>
+
+<div id="content">
+{{content}}
+</div>
+
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-40966673-1', 'r-project.org');
+  ga('send', 'pageview');
+</script>
+</body>
+</html>

--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -50,6 +50,11 @@ ISSN: 2073-4859</p>
 </ul></div>
 
 <div id="content">
+
+  <h1><a href="{{page.pdf}}">{{page.title}}</a></h1>
+  <h2> {% for author in page.author %} {{ author }}    {% endfor %}
+  <em>{{site.title}}</em>  {{page.vol}}({{page.num}}) pp {{ page.pages[0] }} -- {{page.pages[1] }}  {{ page.year }} </h2>  
+  
 {{content}}
 </div>
 

--- a/_plugins/article_html_pages.rb
+++ b/_plugins/article_html_pages.rb
@@ -1,7 +1,7 @@
 module Jekyll
 
   class CategoryArticle < Page
-    def initialize(site, base, dir, title, author, pages, issue, pdf)
+    def initialize(site, base, dir, title, author, pages, issue, pdf, num, volume, year, month)
       @site = site
       @base = base
       @dir = dir
@@ -14,8 +14,11 @@ module Jekyll
       self.data['title'] = title 
       self.data['author'] = author 
       self.data['pages'] = pages 
-      self.data['issue'] = issue 
       self.data['pdf'] = pdf 
+      self.data['num'] = num 
+      self.data['volume'] = volume
+      self.data['year'] = year 
+      self.data['month'] = month
     end
   end
 
@@ -33,7 +36,7 @@ module Jekyll
               path = File.join(dir, issue['issue'], slug)
 #              puts path
               pdf = path + ".pdf" 
-              site.pages << CategoryArticle.new(site, site.source, path, article['title'], article['author'], article['pages'], issue['issue'], pdf)
+              site.pages << CategoryArticle.new(site, site.source, path, article['title'], article['author'], article['pages'], issue['issue'], pdf, issue['num'], issue['volume'], issue['year'], issue['month'])
             end
           end
         end

--- a/_plugins/article_html_pages.rb
+++ b/_plugins/article_html_pages.rb
@@ -1,0 +1,44 @@
+module Jekyll
+
+  class CategoryArticle < Page
+    def initialize(site, base, dir, title, author, pages, issue, pdf)
+      @site = site
+      @base = base
+      @dir = dir
+      @name = 'index.html'
+
+      self.process(@name)
+      self.read_yaml(File.join(base, '_layouts'), 'article.html')
+      ## Add the metadata to the page yaml, so it is
+      ## available to liquid calls in article.html template
+      self.data['title'] = title 
+      self.data['author'] = author 
+      self.data['pages'] = pages 
+      self.data['issue'] = issue 
+      self.data['pdf'] = pdf 
+    end
+  end
+
+  class CategoryArticleGenerator < Generator
+    safe true
+
+    def generate(site)
+      dir = "archive"
+      site.config['issues'].each do |issue|
+        
+        if issue['issue'] != 'accepted'
+          issue['articles'].each do |article|
+            slug = article['slug']
+            if(!slug.nil?)
+              path = File.join(dir, issue['issue'], slug)
+#              puts path
+              pdf = path + ".pdf" 
+              site.pages << CategoryArticle.new(site, site.source, path, article['title'], article['author'], article['pages'], issue['issue'], pdf)
+            end
+          end
+        end
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
The landing pages are created by a plugin, `article_html_pages.rb` using the metadata in `_config.yaml`.  

For each article, there is now an HTML page at `archives/<issue>/<slug>`, so that stripping the `.pdf` from the article links will give the HTML versions.  These pages contain the citation information in plain text, and in the HTML head `meta` elements in Dublin Core and Google / Highwire notation.  

I did notice a few minor inconsistencies in the `_config.yaml`: only the latest issue has a volume number assigned, and the formatting for 2013-1 issue is slightly different as well.  Not really a problem, only that volume number is consequently not available for those entries.  

I did not change any of the existing index files, so these still point to the pdfs directly as they did before, and not to the HTML landing pages.  Not sure if you want to leave it that way or direct them to the HTML.  
- Carl

p.s. The whole idea of doing a pull request for a journal is awesome by the way.  Don't want to make more work for you, but might be nice to share a short comment about R-journal "open for pull requests" on my blog, if that's all right?
