### PR TITLE
Fix Henze–Zirkler lognormal parameters in RJ-2014-031

### DIFF
--- a/_articles/RJ-2014-031/RJ-2014-031.Rmd
+++ b/_articles/RJ-2014-031/RJ-2014-031.Rmd
@@ -186,12 +186,12 @@ distance of $i^{\text{th}}$ observation to the centroid and $D_{ij}$
 gives the Mahalanobis distance between $i^{\text{th}}$ and
 $j^{\text{th}}$ observations. If data are multivariate normal, the test
 statistic ($HZ$) is approximately log-normally distributed with mean
-$\mu$ and variance $\sigma^2$ as given below:
+$\mu$ and variance $\sigma^2$ as given below (updated 2025-08-29: $\mu$ and $\sigma^2$ corrected):
 
 $$\begin{aligned}
-  \mu       = & \, 1-\frac{a^{-\frac{p}{2}}\left(1 + p\beta^{\frac{2}{a}} + \left(p\left(p+2\right)\beta^4\right)\right)}{2a^2}\\
-  \sigma^2  = & \, 2\left(1+4\beta^2\right)^{-\frac{p}{2}} + \frac{2a^{-p}\left(1+2p\beta^4\right)}{a^2} + \frac{3p\left(p+2\right)\beta^8}{4a^4} \\ 
-              & \, - 4{w_\beta}^{-\frac{p}{2}}\left(1+\frac{3p\beta^4}{2w_\beta}+\frac{p\left(p+2\right)\beta^8}{2{w_\beta}^{2}}\right)
+  \mu       = & \, 1 - a^{-p/2}\left(1 + \frac{p\,\beta^{2}}{a} + \frac{p(p+2)\,\beta^{4}}{2a^{2}}\right)\\
+  \sigma^2  = & \, 2(1+4\beta^{2})^{-p/2} + 2a^{-p}\!\left(1 + \frac{2p\beta^{4}}{a^{2}} + \frac{3p(p+2)\beta^{8}}{4a^{4}}\right)\\ 
+              & \, - 4w_{\beta}^{-p/2}\!\left(1 + \frac{3p\beta^{4}}{2w_{\beta}} + \frac{p(p+2)\beta^{8}}{2w_{\beta}^{2}}\right)
 \end{aligned}$$
 
 where $a = 1 + 2\beta^2$ and $w_\beta = (1+\beta^2)(1+3\beta^2)$. Hence,


### PR DESCRIPTION
Corrects the printed formulas for the Henze–Zirkler (HZ) test’s lognormal parameters in RJ-2014-031.Rmd. Adds a brief parenthetical “updated” note in the text.