### PR TITLE
Fix bibliography of RJ-2025-034

### DIFF
--- a/_articles/RJ-2025-034/longevity.bib
+++ b/_articles/RJ-2025-034/longevity.bib
@@ -188,8 +188,8 @@
 	volume       = 6,
 	number       = 2,
 	pages        = {243 -- 284},
-	doi          = {bj/1081788028},
-	url          = {https://doi.org/}
+	doi          = {10.2307/3318576},
+	url          = {https://doi.org/10.2307/3318576}
 }
 @article{evd,
 	title        = {{evd}: Extreme Value Distributions},


### PR DESCRIPTION
Correct a broken URL/DOI in the references that lead to an empty URL.